### PR TITLE
Add RSAT domain for Royston schools

### DIFF
--- a/lib/domains/uk/org/rsat.txt
+++ b/lib/domains/uk/org/rsat.txt
@@ -1,0 +1,1 @@
+Royston Schools' Academy Trust


### PR DESCRIPTION
The Meridian School
The Greneway School
Roysia
The above are schools in the RSAT trust.